### PR TITLE
Add support for child_process.spawnSync

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -40,6 +40,17 @@ var expect = 'WRAP ["{{FIXTURE}}","xyz"]\n' +
   '["xyz"]\n' +
   'EXIT [0,null]\n'
 
+// dummy for node v0.10
+if (!cp.spawnSync) {
+  cp.spawnSync = function () {
+    return {
+      status: 0,
+      signal: null,
+      stdout: expect
+    }
+  }
+}
+
 t.test('spawn execPath', function (t) {
   t.plan(4)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -41,7 +41,7 @@ var expect = 'WRAP ["{{FIXTURE}}","xyz"]\n' +
   'EXIT [0,null]\n'
 
 t.test('spawn execPath', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   t.test('basic', function (t) {
     var child = cp.spawn(process.execPath, [fixture, 'xyz'])
@@ -56,6 +56,15 @@ t.test('spawn execPath', function (t) {
       t.equal(out, expect)
       t.end()
     })
+  })
+
+  t.test('basic sync', function (t) {
+    var child = cp.spawnSync(process.execPath, [fixture, 'xyz'])
+
+    t.equal(child.status, 0)
+    t.equal(child.signal, null)
+    t.equal(child.stdout.toString(), expect)
+    t.end()
   })
 
   t.test('SIGINT', { skip: winNoSig }, function (t) {
@@ -104,7 +113,7 @@ t.test('spawn execPath', function (t) {
 })
 
 t.test('spawn node', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   t.test('basic', function (t) {
     var child = cp.spawn('node', [fixture, 'xyz'])
@@ -119,6 +128,15 @@ t.test('spawn node', function (t) {
       t.equal(out, expect)
       t.end()
     })
+  })
+
+  t.test('basic sync', function (t) {
+    var child = cp.spawnSync('node', [fixture, 'xyz'])
+
+    t.equal(child.status, 0)
+    t.equal(child.signal, null)
+    t.equal(child.stdout.toString(), expect)
+    t.end()
   })
 
   t.test('SIGINT', { skip: winNoSig }, function (t) {


### PR DESCRIPTION
Wrap `process.binding('spawn_sync').spawn` so that calls to `child_process.spawnSync()` are intercepted, too.