### PR TITLE
Add special handling for spawning `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "mkdirp": "^0.5.0",
     "os-homedir": "^1.0.1",
     "rimraf": "^2.3.3",
-    "signal-exit": "^2.0.0"
+    "signal-exit": "^2.0.0",
+    "which": "^1.2.4"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,6 +6,7 @@ var winNoSig = isWindows && 'no signals get through cmd'
 var onExit = require('signal-exit')
 var cp = require('child_process')
 var fixture = require.resolve('./fixtures/script.js')
+var npmFixture = require.resolve('./fixtures/npm')
 var fs = require('fs')
 var path = require('path')
 
@@ -290,6 +291,41 @@ t.test('exec shebang', { skip: winNoShebang }, function (t) {
         'EXIT [0,null]\n')
       t.end()
     })
+  })
+})
+
+// see: https://github.com/bcoe/nyc/issues/190
+t.test('Node 5.8.x + npm 3.7.x - spawn', { skip: winNoShebang }, function (t) {
+  var npmdir = path.dirname(npmFixture)
+  process.env.PATH = npmdir + ':' + (process.env.PATH || '')
+  var child = cp.spawn('npm', ['xyz'])
+
+  var out = ''
+  child.stdout.on('data', function (c) {
+    out += c
+  })
+  child.on('close', function (code, signal) {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.true(~out.indexOf('xyz'))
+    t.end()
+  })
+})
+
+t.test('Node 5.8.x + npm 3.7.x - shell', { skip: winNoShebang }, function (t) {
+  var npmdir = path.dirname(npmFixture)
+  process.env.PATH = npmdir + ':' + (process.env.PATH || '')
+  var child = cp.exec('npm xyz')
+
+  var out = ''
+  child.stdout.on('data', function (c) {
+    out += c
+  })
+  child.on('close', function (code, signal) {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.true(~out.indexOf('xyz'))
+    t.end()
   })
 })
 

--- a/test/fixtures/npm
+++ b/test/fixtures/npm
@@ -1,0 +1,4 @@
+#!/bin/sh
+// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"
+console.log('%j', process.execArgv)
+console.log('%j', process.argv.slice(2))


### PR DESCRIPTION
As laid out in bcoe/nyc#190, spawn-wrap’ing `npm` does currently not work when using the `npm` binary that comes bundled with Node.js.

This adds special handler code for the case that `npm` is the program that should be executed, looking for the `npm` executable in PATH and invoking the shim with it as an argument.

/cc @bcoe 