### PR TITLE
Detect shebangs absolutely to node, wrap those too

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,13 @@ function wrap (argv, env, workingDir) {
               exe === cmdname) {
             c = c.replace(re, '$1 ' + workingDir + '/node')
             options.args[cmdi + 1] = c
+          } else if (exe === 'npm' && !isWindows) {
+            var npmPath = whichOrUndefined('npm')
+
+            if (npmPath) {
+              c = c.replace(re, '$1 ' + workingDir + '/node ' + npmPath)
+              options.args[cmdi + 1] = c
+            }
           }
         }
       }
@@ -133,12 +140,31 @@ function wrap (argv, env, workingDir) {
       options.envPairs.push((isWindows ? 'Path=' : 'PATH=') + workingDir)
     }
 
+    if (file === 'npm' && !isWindows) {
+      var npmPath = whichOrUndefined('npm')
+
+      if (npmPath) {
+        options.args[0] = npmPath
+
+        options.file = workingDir + '/node'
+        options.args.unshift(workingDir + '/node')
+      }
+    }
+
     if (isWindows) fixWindowsBins(workingDir, options)
 
     return spawn.call(this, options)
   }
 
   return unwrap
+}
+
+function whichOrUndefined (executable) {
+  var path
+  try {
+    path = which.sync(executable)
+  } catch (er) {}
+  return path
 }
 
 // by default Windows will reference the full

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "mkdirp": "^0.5.0",
     "os-homedir": "^1.0.1",
     "rimraf": "^2.3.3",
-    "signal-exit": "^2.0.0"
+    "signal-exit": "^2.0.0",
+    "which": "^1.2.4"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/abs-shebang.js
+++ b/test/abs-shebang.js
@@ -1,0 +1,67 @@
+var path = require('path')
+var fs = require('fs')
+var spawn = require('child_process').spawn
+var t = require('tap')
+var node = process.execPath
+var wrap = require.resolve('./fixtures/wrap.js')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var fs = require('fs')
+
+if (process.platform === 'windows') {
+  t.plan(0, 'No proper shebang support on windows, so skip this')
+  process.exit(0)
+}
+
+var expect =
+  'before in shim\n' +
+  'shebang main\n' +
+  'after in shim\n' +
+  'before in shim\n' +
+  'shebang main\n' +
+  'after in shim\n'
+
+var fixdir = path.resolve(__dirname, 'fixtures', 'shebangs')
+
+t.test('setup', function (t) {
+  rimraf.sync(fixdir)
+  mkdirp.sync(fixdir)
+  t.end()
+})
+
+t.test('absolute', function (t) {
+  var file = path.resolve(fixdir, 'absolute.js')
+  runTest(file, process.execPath, t)
+})
+
+t.test('env', function (t) {
+  var file = path.resolve(fixdir, 'env.js')
+  runTest(file, '/usr/bin/env node', t)
+})
+
+function runTest (file, shebang, t) {
+  var content = '#!' + shebang + '\nconsole.log("shebang main")\n'
+  fs.writeFileSync(file, content, 'utf8')
+  fs.chmodSync(file, '0755')
+  var child = spawn(node, [wrap, file])
+  var out = ''
+  var err = ''
+  child.stdout.on('data', function (c) {
+    out += c
+  })
+  child.stderr.on('data', function (c) {
+    err += c
+  })
+  child.on('close', function (code,  signal) {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.equal(out, expect)
+    // console.error(err)
+    t.end()
+  })
+}
+
+t.test('cleanup', function (t) {
+  rimraf.sync(fixdir)
+  t.end()
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,6 +6,7 @@ var winNoSig = isWindows && 'no signals get through cmd'
 var onExit = require('signal-exit')
 var cp = require('child_process')
 var fixture = require.resolve('./fixtures/script.js')
+var npmFixture = require.resolve('./fixtures/npm')
 var fs = require('fs')
 var path = require('path')
 
@@ -290,6 +291,41 @@ t.test('exec shebang', { skip: winNoShebang }, function (t) {
         'EXIT [0,null]\n')
       t.end()
     })
+  })
+})
+
+// see: https://github.com/bcoe/nyc/issues/190
+t.test('Node 5.8.x + npm 3.7.x - spawn', { skip: winNoShebang }, function (t) {
+  var npmdir = path.dirname(npmFixture)
+  process.env.PATH = npmdir + ':' + (process.env.PATH || '')
+  var child = cp.spawn('npm', ['xyz'])
+
+  var out = ''
+  child.stdout.on('data', function (c) {
+    out += c
+  })
+  child.on('close', function (code, signal) {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.true(~out.indexOf('xyz'))
+    t.end()
+  })
+})
+
+t.test('Node 5.8.x + npm 3.7.x - shell', { skip: winNoShebang }, function (t) {
+  var npmdir = path.dirname(npmFixture)
+  process.env.PATH = npmdir + ':' + (process.env.PATH || '')
+  var child = cp.exec('npm xyz')
+
+  var out = ''
+  child.stdout.on('data', function (c) {
+    out += c
+  })
+  child.on('close', function (code, signal) {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.true(~out.indexOf('xyz'))
+    t.end()
   })
 })
 

--- a/test/fixtures/npm
+++ b/test/fixtures/npm
@@ -1,0 +1,4 @@
+#!/bin/sh
+// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"
+console.log('%j', process.execArgv)
+console.log('%j', process.argv.slice(2))

--- a/test/fixtures/npm
+++ b/test/fixtures/npm
@@ -2,3 +2,4 @@
 // 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"
 console.log('%j', process.execArgv)
 console.log('%j', process.argv.slice(2))
+setTimeout(function () {}, 100)

--- a/test/fixtures/test-shim.js
+++ b/test/fixtures/test-shim.js
@@ -1,0 +1,3 @@
+console.log('before in shim')
+require('../..').runMain()
+console.log('after in shim')

--- a/test/fixtures/wrap.js
+++ b/test/fixtures/wrap.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+var sw = require('../..')
+
+sw([require.resolve('./test-shim.js')])
+
+var path = require('path')
+var spawn = require('child_process').spawn
+
+spawn(path.resolve(process.argv[2]), process.argv.slice(3), {
+  stdio: 'inherit'
+}).on('close', function (code, signal) {
+  if (code || signal) {
+    throw new Error('failed with ' + (code || signal))
+  }
+
+  // now run using PATH
+  process.env.PATH = path.resolve(path.dirname(process.argv[2])) +
+    ':' + process.env.PATH
+
+  spawn(path.basename(process.argv[2]), process.argv.slice(3), {
+    stdio: 'inherit',
+  }, function (code, signal) {
+    if (code || signal) {
+      throw new Error('failed with ' + (code || signal))
+    }
+  })
+})


### PR DESCRIPTION
When there's a program that doesn't match one of the other criteria, read its contents, and if it's a shebang to node, then wrap it.

This lets nyc wrap npm when npm is a shebang to an absolute path to Node.

Closes #12 

