### PR TITLE
Node 0.10 has never worked on appveyor, let's disable it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: '5'
     - nodejs_version: '4'
     - nodejs_version: '0.12'
-    - nodejs_version: '0.10'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
I tried to get the tests running in Node 0.10 by disabling them one by one, Node 0.10 continues to fail. Since this has never worked, and is making it hard to land patches for people let's just disable it.