### PR TITLE
Resolve race condition in tests by keeping event loop alive

### DIFF
--- a/test/fixtures/script.js
+++ b/test/fixtures/script.js
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
 console.log('%j', process.execArgv)
 console.log('%j', process.argv.slice(2))
+
+// Keep the event loop alive long enough to receive signals.
+setTimeout(function() {}, 100)


### PR DESCRIPTION
Add a dummy setTimeout() call that keeps the event loop alive long enough to receive signals.
There may be better ways to do this, but this is simple and seems sufficiently reliable.

See: https://github.com/tapjs/spawn-wrap/pull/8#issuecomment-205278402