### PR TITLE
use child_process.ChildProcess if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ wrap.runMain = runMain
 
 var Module = require('module')
 var fs = require('fs')
-var ChildProcess
+var cp = require('child_process')
+var ChildProcess = cp.ChildProcess
 var assert = require('assert')
 var crypto = require('crypto')
 var mkdirp = require('mkdirp')
@@ -28,8 +29,7 @@ var colon = isWindows ? ';' : ':'
 
 function wrap (argv, env, workingDir) {
   if (!ChildProcess) {
-    // sure would be nice if the class were exposed...
-    var child = require('child_process').spawn(process.execPath, [])
+    var child = cp.spawn(process.execPath, [])
     ChildProcess = child.constructor
     child.kill('SIGKILL')
   }


### PR DESCRIPTION
This prevents having to spawn an additional process to get the
ChildProcess constructor. The ChildProcess constructor has been exposed
on require('child_process') since iojs v2.2.0

Same as #8, but rebased on master.  If travis passes, will land and push to v1.2.1.