### PR TITLE
Fixups for the recent shebang changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,12 +162,11 @@ function wrappedSpawnFunction (fn, workingDir) {
           var shebangbin = match[1].split(' ')[0]
           var maybeNode = path.basename(shebangbin)
           if (maybeNode === 'node' || maybeNode === 'iojs' || cmdname === maybeNode) {
-
-            options.file = shebangbin
+            file = options.file = shebangbin
             options.args = [shebangbin, workingDir + '/' + maybeNode]
               .concat(resolved)
               .concat(match[1].split(' ').slice(1))
-              .concat(options.args)
+              .concat(options.args.slice(1))
           }
         }
       }

--- a/test/abs-shebang.js
+++ b/test/abs-shebang.js
@@ -15,10 +15,10 @@ if (process.platform === 'win32') {
 
 var expect =
   'before in shim\n' +
-  'shebang main\n' +
+  'shebang main foo,bar\n' +
   'after in shim\n' +
   'before in shim\n' +
-  'shebang main\n' +
+  'shebang main foo,bar\n' +
   'after in shim\n'
 
 var fixdir = path.resolve(__dirname, 'fixtures', 'shebangs')
@@ -40,10 +40,11 @@ t.test('env', function (t) {
 })
 
 function runTest (file, shebang, t) {
-  var content = '#!' + shebang + '\nconsole.log("shebang main")\n'
+  var content = '#!' + shebang + '\n' +
+    'console.log("shebang main " + process.argv.slice(2))\n'
   fs.writeFileSync(file, content, 'utf8')
   fs.chmodSync(file, '0755')
-  var child = spawn(node, [wrap, file])
+  var child = spawn(node, [wrap, file, 'foo', 'bar'])
   var out = ''
   var err = ''
   child.stdout.on('data', function (c) {

--- a/test/abs-shebang.js
+++ b/test/abs-shebang.js
@@ -8,7 +8,7 @@ var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var fs = require('fs')
 
-if (process.platform === 'windows') {
+if (process.platform === 'win32') {
   t.plan(0, 'No proper shebang support on windows, so skip this')
   process.exit(0)
 }


### PR DESCRIPTION
`options.args[0]` already contains the executable name (it is unshifted by [child_process.spawn](https://github.com/nodejs/node/blob/85ab4a5f1281c4e1dd06450ac7bd3250326267fa/lib/child_process.js#L340)), so it should not be included in the newly built `options.args` array when a shebang is found, because the script’s file name is already passed as `resolved`.

Also set the local `file` variable to the new executable so spawn-wrap does not attempt to double-fix in the case of encountering `file === 'npm'`.

/cc @bcoe @isaacs