### PR TITLE
Support running "/path/to/node" in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,10 +87,17 @@ function wrappedSpawnFunction (fn, workingDir) {
       cmdi = options.args.indexOf('-c')
       if (cmdi !== -1) {
         c = options.args[cmdi + 1]
-        re = /^\s*((?:[^\= ]*\=[^\=\s]*\s*)*)([^\s]+)/
+        re = /^\s*((?:[^\= ]*\=[^\=\s]*\s*)*)([^\s]+|"[^"]+"|'[^']+')/
         match = c.match(re)
         if (match) {
           exe = path.basename(match[2])
+          // Strip a trailing quote from the basename if it matches a
+          // leading quote.
+          var quote = match[2].charAt(0)
+          if ((quote === '"' || quote === '\'') && quote === exe.slice(-1)) {
+            exe = exe.slice(0, -1)
+          }
+
           if (exe === 'iojs' ||
               exe === 'node' ||
               exe === cmdname) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -197,11 +197,28 @@ t.test('spawn node', function (t) {
 })
 
 t.test('exec execPath', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   t.test('basic', function (t) {
     var opt = isWindows ? null : { shell: '/bin/bash' }
     var child = cp.exec(process.execPath + ' ' + fixture + ' xyz', opt)
+
+    var out = ''
+    child.stdout.on('data', function (c) {
+      out += c
+    })
+    child.on('close', function (code, signal) {
+      t.equal(code, 0)
+      t.equal(signal, null)
+      t.equal(out, expect)
+      t.end()
+    })
+  })
+
+  t.test('execPath wrapped with quotes', function (t) {
+    var opt = isWindows ? null : { shell: '/bin/bash' }
+    var child = cp.exec(JSON.stringify(process.execPath) + ' ' + fixture +
+      ' xyz', opt)
 
     var out = ''
     child.stdout.on('data', function (c) {


### PR DESCRIPTION
When spawning Node child process using the shell, some people like to wrap their arguments in quotes.

spawn-wrap is currently thrown off by this, because it doesn’t understand a basename like `node"`, as returned for e.g. `"/usr/bin/node"`. This patch removes those trailing quotes before checking against `node` and `iojs` and detects simple kinds of quoting the exec path.

Ref: https://github.com/shelljs/shelljs/issues/438 and /cc @bcoe @isaacs 