### PR TITLE
Special `npm` handling for Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/index.js
+++ b/index.js
@@ -119,7 +119,9 @@ function wrappedSpawnFunction (fn, workingDir) {
       )) {
       cmdi = options.args.indexOf('/c')
       if (cmdi !== -1) {
-        options.args[cmdi + 1] = winRebase(options.args[cmdi + 1], workingDir + '/node.cmd')
+        options.args[cmdi + 1] = winRebase(options.args[cmdi + 1],
+                                           workingDir + '/node.cmd',
+                                           whichOrUndefined)
       }
     } else if (file === 'node' || file === 'iojs' || cmdname === file) {
       // make sure it has a main script.

--- a/lib/win-rebase.js
+++ b/lib/win-rebase.js
@@ -1,8 +1,17 @@
 var re = /^\s*("*)([^"]*?\b(?:node|iojs)(?:\.exe)?)("*)( |$)/
+var npmre = /^\s*("*)([^"]*?\b(?:npm))("*)( |$)/
+var path_ = require('path')
+if (path_.win32) path_ = path_.win32
 
-module.exports = function (path, rebase) {
+module.exports = function (path, rebase, whichOrUndefined) {
   var m = path.match(re)
-  if (!m) return path
+  if (!m) {
+    m = path.match(npmre)
+    if (!m) return path
+    var npmPath = whichOrUndefined('npm') || 'npm'
+    npmPath = path_.dirname(npmPath) + '\\node_modules\\npm\\bin\\npm-cli.js'
+    return path.replace(npmre, m[1] + rebase + ' "' + npmPath + '"' + m[3] + m[4])
+  }
   // preserve the quotes
   var replace = m[1] + rebase + m[3] + m[4]
   return path.replace(re, replace)

--- a/test/fixtures/node_modules/npm/bin/npm-cli.js
+++ b/test/fixtures/node_modules/npm/bin/npm-cli.js
@@ -1,0 +1,4 @@
+'use strict';
+console.log('%j', process.execArgv)
+console.log('%j', process.argv.slice(2))
+setTimeout(function () {}, 100)

--- a/test/fixtures/npm.cmd
+++ b/test/fixtures/npm.cmd
@@ -1,0 +1,2 @@
+@echo This code should never be executed.
+exit /B 1

--- a/test/win-rebase.js
+++ b/test/win-rebase.js
@@ -30,3 +30,11 @@ t.test('handles many quotes', function (t) {
   t.equal(result, '""C:\\foo" "foo.js""')
   t.end()
 })
+
+t.test('handles npm invocations', function (t) {
+  var result = winRebase('""npm" "install""',
+                         'C:\\foo',
+                         function() { return 'C:\\path-to-npm\\npm' })
+  t.equal(result, '""C:\\foo "C:\\path-to-npm\\node_modules\\npm\\bin\\npm-cli.js"" "install""')
+  t.end()
+})


### PR DESCRIPTION
Fixes a variant of https://github.com/istanbuljs/nyc/issues/190 for Windows when the `npm.cmd` shim is invoked from the shell (i.e. `cmd /s /c`).

Fixes: https://github.com/istanbuljs/nyc/issues/300

@mewdriller … Could you try and check the quoting here is right? I’m not a hundred percent sure.

Also /cc @bcoe