### PR TITLE
strip .exe suffix via case-insensitive replacement (fixes #55 and #56)

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,10 @@ function isNode (file) {
 
 function mungeNode (workingDir, options) {
   options.originalNode = options.file
-  var command = path.basename(options.file, '.exe')
+  // Strip a '.exe' extension via a case-insensitive replacement
+  // rather than via the case-sensitive 'ext` parameter to path.basename
+  // because it might be capitalized ('.EXE').
+  var command = path.basename(options.file).replace(/\.exe$/i, '')
   // make sure it has a main script.
   // otherwise, just let it through.
   var a = 0

--- a/test/basic.js
+++ b/test/basic.js
@@ -197,8 +197,9 @@ t.test('exec execPath', function (t) {
 
   t.test('basic', function (t) {
     var opt = isWindows ? null : { shell: '/bin/bash' }
-    var child = cp.exec(process.execPath + ' ' + fixture + ' xyz', opt)
-
+    // Enclose process.execPath in quotes in case it contains spaces
+    // (especially on Windows, where it might contain "Program Files").
+    var child = cp.exec('"' + process.execPath + '"' + ' ' + fixture + ' xyz', opt)
     var out = ''
     child.stdout.on('data', function (c) {
       out += c

--- a/test/exec-flag.js
+++ b/test/exec-flag.js
@@ -1,4 +1,5 @@
 var sw = require('../')
+var isWindows = require('../lib/is-windows.js')()
 
 if (process.argv[2] === 'wrapper') {
   // note: this should never happen,
@@ -34,10 +35,14 @@ t.test('wrap a -e invocation', function (t) {
           code: code,
           signal: signal
         }
+        // Per <https://nodejs.org/api/process.html>, "Sending SIGINT,
+        // SIGTERM, and SIGKILL cause the unconditional termination
+        // of the target process."  So Node ignores our SIGTERM handler,
+        // and the process ends when killed with that signal.
         var expect = {
-          out: /^(wtf\n)*ignore!\n(wtf\n)*$/,
+          out: isWindows ? /^(wtf\n)*$/ : /^(wtf\n)*ignore!\n(wtf\n)*$/,
           code: null,
-          signal: 'SIGKILL'
+          signal: isWindows ? 'SIGTERM' : 'SIGKILL'
         }
         t.match(actual, expect)
         t.end()


### PR DESCRIPTION
Strip a '.exe' extension via a case-insensitive replacement rather than via the case-sensitive 'ext` parameter to path.basename because it might be capitalized ('.EXE'). This fixes #56 for me when testing https://github.com/mozilla/qbrt, which uses https://github.com/tapjs/node-tap, which uses https://github.com/istanbuljs/nyc, which uses this package.
