### PR TITLE
test: increase test timeout for citgm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "which": "^1.2.4"
   },
   "scripts": {
-    "test": "tap test/*.js",
+    "test": "tap --timeout=240 test/*.js",
     "preversion": "npm test",
     "postversion": "npm publish",
     "postpublish": "git push origin --all; git push origin --tags",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/isaacs/spawn-wrap#readme",
   "devDependencies": {
-    "tap": "^10.1.0"
+    "tap": "^10.7.2"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
upgrade version of tap and increase timeout, to see if this is in-fact the issue with CITGM (see #60).

@MylesBorins are you able to run CITGM against a branch, so that we can try isolating this issue before we increase the timeout?