### PR TITLE
fix(typo): shebang is not defined, #67

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,7 @@ var debug = doDebug ? function () {
   process.stderr.write(message + '\n')
 } : function () {}
 
-if (process.platform === 'os390')
-  shebang = '#!/bin/env '
-else
-  shebang = '#!'
+var shebang = (process.platform === 'os390') ? '#!/bin/env ' : '#!'
 var shim = shebang + process.execPath + '\n' +
   fs.readFileSync(__dirname + '/shim.js')
 


### PR DESCRIPTION
https://github.com/tapjs/spawn-wrap/issues/67